### PR TITLE
Make sure $GOBIN is set

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -13,8 +13,12 @@ if [[ -n "${BUILDKITE_PLUGIN_GOLANG_IMPORT:-}" ]]; then
   export BUILDKITE_BUILD_CHECKOUT_PATH="$GOPATH/src/$BUILDKITE_PLUGIN_GOLANG_IMPORT"
   echo "BUILDKITE_BUILD_CHECKOUT_PATH=$BUILDKITE_BUILD_CHECKOUT_PATH"
 
+  # Make sure go get/install binaries are installed in the right place
+  export GOBIN="$GOPATH/bin"
+  echo "GOBIN=$GOBIN"
+
   # Add golang bin commands to path
-  export PATH="$PATH:$GOPATH/bin"
+  export PATH="$PATH:$GOBIN"
   echo PATH="$PATH"
 else
   echo "+++ :golang: No 'import' option specified"

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -6,25 +6,30 @@ export BUILDKITE_PLUGIN_GOLANG_IMPORT=my-dir
 export BUILDKITE_BUILD_CHECKOUT_PATH="/builds/my-pipeline"
 export BUILDKITE_PIPELINE_SLUG="my-pipeline"
 
-@test "sets the GOPATH" {
+@test "sets \$GOPATH" {
   run $PWD/hooks/pre-checkout
   
   assert_success
   assert_output --partial "GOPATH=/builds/.golang/my-pipeline"
 }
 
-@test "sets the BUILDKITE_BUILD_CHECKOUT_PATH" {
+@test "sets \$BUILDKITE_BUILD_CHECKOUT_PATH" {
   run $PWD/hooks/pre-checkout
   
   assert_success
   assert_output --partial "BUILDKITE_BUILD_CHECKOUT_PATH=/builds/.golang/my-pipeline/src/my-dir"
 }
 
-@test "adds GOPATH/bin to PATH" {
-  export PATH=/bin
-
+@test "adds \$GOPATH/bin to \$PATH" {
   run $PWD/hooks/pre-checkout
   
   assert_success
-  assert_output --partial "PATH=/bin:/builds/.golang/my-pipeline/bin"
+  assert_output --partial "PATH=$PATH:/builds/.golang/my-pipeline/bin"
+}
+
+@test "sets \$GOBIN" {
+  run $PWD/hooks/pre-checkout
+  
+  assert_success
+  assert_output --partial "GOBIN=/builds/.golang/my-pipeline/bin"
 }


### PR DESCRIPTION
As @lox and I discovered in https://github.com/buildkite-plugins/gopath-checkout-buildkite-plugin/commit/02e95b2b49f0db5d1c148b2941bdf94c069a4ba8#r28849220, we should probably override $GOBIN if we're overriding $GOPATH