### PR TITLE
Fix environment variable name

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [[ -n "${BUILDKITE_PLUGIN_GOLANG_IMPORT:-}" ]]; then
+if [[ -n "${BUILDKITE_PLUGIN_GOPATH_CHECKOUT_IMPORT:-}" ]]; then
   echo "~~~ :golang: Setting GOPATH and checkout path"
 
   # Create a scoped gopath which won't collide with non-plugin checkouts
@@ -10,7 +10,7 @@ if [[ -n "${BUILDKITE_PLUGIN_GOLANG_IMPORT:-}" ]]; then
   echo "GOPATH=$GOPATH"
 
   # Now checkout into the correct import location within that gopath
-  export BUILDKITE_BUILD_CHECKOUT_PATH="$GOPATH/src/$BUILDKITE_PLUGIN_GOLANG_IMPORT"
+  export BUILDKITE_BUILD_CHECKOUT_PATH="$GOPATH/src/$BUILDKITE_PLUGIN_GOPATH_CHECKOUT_IMPORT"
   echo "BUILDKITE_BUILD_CHECKOUT_PATH=$BUILDKITE_BUILD_CHECKOUT_PATH"
 
   # Make sure go get/install binaries are installed in the right place

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -2,7 +2,7 @@
 
 load "$BATS_PATH/load.bash"
 
-export BUILDKITE_PLUGIN_GOLANG_IMPORT=my-dir
+export BUILDKITE_PLUGIN_GOPATH_CHECKOUT_IMPORT=my-dir
 export BUILDKITE_BUILD_CHECKOUT_PATH="/builds/my-pipeline"
 export BUILDKITE_PIPELINE_SLUG="my-pipeline"
 


### PR DESCRIPTION
Currently the environment variable is not set correctly with the latest agent, so using this plugin with the following config in `.buildkite/pipeline.yml` does not work:

```yaml
steps:
  - command: "./run_test"
    label: "Run test"
    plugins:
      gopath-checkout#v1.0.0:
        import: github.com/jdlehman/goproject
```

Based on how agent sets envs based on plugin name and configuration: https://github.com/buildkite/agent/blob/master/agent/plugin.go#L239

this does not work because `BUILDKITE_PLUGIN_GOPATH_CHECKOUT_IMPORT` is set, *not* `BUILDKITE_PLUGIN_GOLANG_IMPORT`. I believe this is a regression from when this plugin was renamed from `golang` to `GOPATH Checkout`.

This change in my fork is now working for me, but would love to see this get merged upstream and for a v1.0.1 release to be tagged.