### PR TITLE
Plugin cleanup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,12 @@
 steps:
   - label: ":bash: Tests"
     plugins:
-      docker-compose#v3.9.0:
+      docker-compose#v4.9.0:
         run: tests
 
   - label: ":bash: Shellcheck"
     plugins:
-      shellcheck#v1.2.0:
+      shellcheck#v1.3.0:
         files:
           - hooks/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.4'
 services:
   tests:
-    image: buildkite/plugin-tester
+    image: buildkite/plugin-tester:v3.0.1
     volumes:
       - ".:/plugin"

--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,5 @@
   "extends": [
     "config:base",
     ":disableDependencyDashboard"
-  ],
-  "docker-compose": {
-    "digest": {
-      "enabled": false
-    }
-  }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":disableDependencyDashboard"
   ],
   "docker-compose": {
     "digest": {

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -1,35 +1,38 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "${BATS_PLUGIN_PATH}/load.bash"
 
 export BUILDKITE_PLUGIN_GOPATH_CHECKOUT_IMPORT=my-dir
 export BUILDKITE_BUILD_CHECKOUT_PATH="/builds/my-pipeline"
 export BUILDKITE_PIPELINE_SLUG="my-pipeline"
 
-@test "sets \$GOPATH" {
-  run $PWD/hooks/pre-checkout
+@test "all variables are printed out" {
+  run "$PWD"/hooks/pre-checkout
   
   assert_success
   assert_output --partial "GOPATH=/builds/.golang/my-pipeline"
-}
-
-@test "sets \$BUILDKITE_BUILD_CHECKOUT_PATH" {
-  run $PWD/hooks/pre-checkout
-  
-  assert_success
   assert_output --partial "BUILDKITE_BUILD_CHECKOUT_PATH=/builds/.golang/my-pipeline/src/my-dir"
-}
-
-@test "adds \$GOPATH/bin to \$PATH" {
-  run $PWD/hooks/pre-checkout
-  
-  assert_success
   assert_output --partial "PATH=$PATH:/builds/.golang/my-pipeline/bin"
+  assert_output --partial "GOBIN=/builds/.golang/my-pipeline/bin"
 }
 
-@test "sets \$GOBIN" {
-  run $PWD/hooks/pre-checkout
+@test "all variables change values" {
+  env | sort > "${BATS_TMP_DIR}"/before
+  run bash -c ". \"$PWD\"/hooks/pre-checkout; env | sort > \"${BATS_TMP_DIR}\"/after"
+  [ "$(grep GOPATH "${BATS_TMP_DIR}"/before)" != "$(grep GOPATH "${BATS_TMP_DIR}"/after)" ]
+  [ "$(grep BUILDKITE_BUILD_CHECKOUT_PATH "${BATS_TMP_DIR}"/before)" != "$(grep BUILDKITE_BUILD_CHECKOUT_PATH "${BATS_TMP_DIR}"/after)" ]
+  [ "$(grep PATH "${BATS_TMP_DIR}"/before)" != "$(grep PATH "${BATS_TMP_DIR}"/after)" ]
+  [ "$(grep GOBIN "${BATS_TMP_DIR}"/before)" != "$(grep GOBIN "${BATS_TMP_DIR}"/after)" ]
+
+  assert_success
+}
+
+@test "all variables have the correct values" {
+  run bash -c ". \"$PWD\"/hooks/pre-checkout; env | sort > \"${BATS_TMP_DIR}\"/after"
   
   assert_success
-  assert_output --partial "GOBIN=/builds/.golang/my-pipeline/bin"
+  grep 'GOPATH=/builds/.golang/my-pipeline' "${BATS_TMP_DIR}"/after
+  grep 'BUILDKITE_BUILD_CHECKOUT_PATH=/builds/.golang/my-pipeline/src/my-dir' "${BATS_TMP_DIR}"/after
+  [[ "$(grep PATH "${BATS_TMP_DIR}"/after)" =~ (^|:)/builds/.golang/my-pipeline/bin(:|$) ]]
+  grep 'GOBIN=/builds/.golang/my-pipeline/bin' "${BATS_TMP_DIR}"/after
 }


### PR DESCRIPTION
Some maintenance on the plugin:
* deactivates the dependency dashboard (closes #40)
* updates dependencies (same as #44, #43 and #45)
* pins plugin tester image and removes the ignore configuration on it
* corrected issue that prevented tests from running
* refactored tests to check env vars and not just plugin output